### PR TITLE
Special tokens and more

### DIFF
--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -220,6 +220,11 @@ class BaseLM(LM):
             else:
                 context_enc, continuation_enc = self._encode_pair(context, continuation)
 
+            if hasattr(self.tokenizer, "add_bos_token") and self.tokenizer.add_bos_token:
+                context_enc.insert(0, self.tokenizer.bos_token_id)
+            if hasattr(self.tokenizer, "add_eos_token") and self.tokenizer.add_eos_token:
+                continuation_enc.append(self.tokenizer.eos_token_id)
+
             new_reqs.append(((context, continuation), context_enc, continuation_enc))
 
         return self._loglikelihood_tokens(new_reqs)

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -87,38 +87,6 @@ def simple_evaluate(
                 "device": device,
             },
         )
-
-
-
-        model_args = simple_parse_args_string(model_args)
-        recipe_file = os.path.join(model_args["pretrained"], "recipe.yaml")
-        if "pretrained" in model_args and os.path.exists(recipe_file):
-
-            if "trust_remote_code" in model_args:
-                trust_remote_code = model_args["trust_remote_code"]
-            else:
-                trust_remote_code = False
-
-            config = transformers.AutoConfig.from_pretrained(
-                model_args["pretrained"],
-                trust_remote_code=trust_remote_code,
-            )
-
-            if "dtype" in model_args:
-                torch_dtype = getattr(torch, model_args["dtype"])
-            else:
-                torch_dtype = "auto"
-
-            lm.model = SparseAutoModel.text_generation_from_pretrained(
-                model_name_or_path=model_args["pretrained"],
-                config=config,
-                recipe=recipe_file,
-                trust_remote_code=trust_remote_code,
-                torch_dtype=torch_dtype,
-            )
-            lm.model.to(device)
-            no_cache = True
-
     elif isinstance(model, transformers.PreTrainedModel):
         lm = lm_eval.models.get_model("hf-causal")(
             pretrained=model,

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -6,8 +6,7 @@ import lm_eval.metrics
 import lm_eval.models
 import lm_eval.tasks
 import lm_eval.base
-from lm_eval.utils import positional_deprecated, run_task_tests, simple_parse_args_string
-from lm_eval.models.gpt2 import HFLM
+from lm_eval.utils import positional_deprecated, run_task_tests
 
 import torch
 import numpy as np

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -13,12 +13,6 @@ import torch
 import numpy as np
 import transformers
 
-from sparseml.core.framework import Framework
-import sparseml.core.session as session_manager
-from sparseml.transformers.utils import SparseAutoModel
-import os
-import math
-
 @positional_deprecated
 def simple_evaluate(
     model,

--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -9,14 +9,13 @@ import lm_eval.base
 from lm_eval.utils import positional_deprecated, run_task_tests, simple_parse_args_string
 from lm_eval.models.gpt2 import HFLM
 
-
+import torch
 import numpy as np
 import transformers
 
 from sparseml.core.framework import Framework
 import sparseml.core.session as session_manager
-from sparseml.pytorch.model_load.helpers import apply_recipe_structure_to_model
-from sparseml.transformers.sparsification.obcq.export import load_task_model
+from sparseml.transformers.utils import SparseAutoModel
 import os
 import math
 
@@ -89,6 +88,8 @@ def simple_evaluate(
             },
         )
 
+
+
         model_args = simple_parse_args_string(model_args)
         recipe_file = os.path.join(model_args["pretrained"], "recipe.yaml")
         if "pretrained" in model_args and os.path.exists(recipe_file):
@@ -103,10 +104,18 @@ def simple_evaluate(
                 trust_remote_code=trust_remote_code,
             )
 
-            lm.model = load_task_model("text-generation", model_args["pretrained"], config, trust_remote_code)
-            lm.model.train()
+            if "dtype" in model_args:
+                torch_dtype = getattr(torch, model_args["dtype"])
+            else:
+                torch_dtype = "auto"
 
-            apply_recipe_structure_to_model(lm.model, recipe_file, model_args["pretrained"])
+            lm.model = SparseAutoModel.text_generation_from_pretrained(
+                model_name_or_path=model_args["pretrained"],
+                config=config,
+                recipe=recipe_file,
+                trust_remote_code=trust_remote_code,
+                torch_dtype=torch_dtype,
+            )
             lm.model.to(device)
             no_cache = True
 

--- a/lm_eval/models/__init__.py
+++ b/lm_eval/models/__init__.py
@@ -4,6 +4,7 @@ from . import anthropic_llms
 from . import huggingface
 from . import textsynth
 from . import dummy
+from . import sparseml
 
 MODEL_REGISTRY = {
     "hf": gpt2.HFLM,

--- a/lm_eval/models/__init__.py
+++ b/lm_eval/models/__init__.py
@@ -15,6 +15,7 @@ MODEL_REGISTRY = {
     "anthropic": anthropic_llms.AnthropicLM,
     "textsynth": textsynth.TextSynthLM,
     "dummy": dummy.DummyLM,
+    "sparseml": sparseml.SparseML
 }
 
 

--- a/lm_eval/models/huggingface.py
+++ b/lm_eval/models/huggingface.py
@@ -501,6 +501,8 @@ class HuggingFaceAutoLM(BaseLM):
             else:
                 max_tokens = max_generation_length
 
+            if hasattr(self.tokenizer, "add_bos_token") and self.tokenizer.add_bos_token:
+                context = [self.tokenizer.bos_token + c for c in context]
             token_context = self.tok_encode_batch(context)
 
             responses = self._model_generate(

--- a/lm_eval/models/sparseml.py
+++ b/lm_eval/models/sparseml.py
@@ -1,6 +1,7 @@
 from lm_eval.models.huggingface import AutoCausalLM
 from typing import Optional, Union
 import torch
+import transformers
 from sparseml.transformers.utils.sparse_model import SparseAutoModel
 
 

--- a/lm_eval/models/sparseml.py
+++ b/lm_eval/models/sparseml.py
@@ -1,0 +1,23 @@
+from lm_eval.models.huggingface import AutoCausalLM
+
+
+class SparseML(AutoCausalLM):
+    def _create_auto_model(
+        self,
+        *,
+        pretrained: str,
+        trust_remote_code: Optional[bool] = False,
+        torch_dtype: Optional[Union[str, torch.dtype]] = None,
+        **kwargs,
+    ) -> transformers.AutoModel:
+
+        recipe_file = os.path.join(pretrained, "recipe.yaml")
+
+        model = SparseAutoModel.text_generation_from_pretrained(
+            model_name_or_path=pretrained,
+            config=self._config,
+            recipe=recipe_file,
+            trust_remote_code=trust_remote_code,
+            torch_dtype=torch_dtype,
+        )
+        return model

--- a/lm_eval/models/sparseml.py
+++ b/lm_eval/models/sparseml.py
@@ -1,5 +1,6 @@
 from lm_eval.models.huggingface import AutoCausalLM
 from typing import Optional, Union
+import os
 import torch
 import transformers
 from sparseml.transformers.utils.sparse_model import SparseAutoModel

--- a/lm_eval/models/sparseml.py
+++ b/lm_eval/models/sparseml.py
@@ -3,8 +3,6 @@ from typing import Optional, Union
 import os
 import torch
 import transformers
-from sparseml.transformers.utils.sparse_model import SparseAutoModel
-
 
 class SparseML(AutoCausalLM):
     def _create_auto_model(
@@ -16,8 +14,19 @@ class SparseML(AutoCausalLM):
         **kwargs,
     ) -> transformers.AutoModel:
 
-        recipe_file = os.path.join(pretrained, "recipe.yaml")
+        try:
+            import sparseml
+        except ModuleNotFoundError:
+            raise Exception(
+                "package `sparseml` is not installed. "
+                "Please install it via `pip install sparseml[transformers]`"
+            )
 
+        recipe_file = os.path.join(pretrained, "recipe.yaml")
+        if not os.path.isfile(recipe_file):
+            recipe_file = None
+
+        from sparseml.transformers.utils.sparse_model import SparseAutoModel
         model = SparseAutoModel.text_generation_from_pretrained(
             model_name_or_path=pretrained,
             config=self._config,
@@ -25,4 +34,5 @@ class SparseML(AutoCausalLM):
             trust_remote_code=trust_remote_code,
             torch_dtype=torch_dtype,
         )
+
         return model

--- a/lm_eval/models/sparseml.py
+++ b/lm_eval/models/sparseml.py
@@ -1,4 +1,6 @@
 from lm_eval.models.huggingface import AutoCausalLM
+from typing import Optional, Union
+import torch
 
 
 class SparseML(AutoCausalLM):

--- a/lm_eval/models/sparseml.py
+++ b/lm_eval/models/sparseml.py
@@ -1,6 +1,7 @@
 from lm_eval.models.huggingface import AutoCausalLM
 from typing import Optional, Union
 import torch
+from sparseml.transformers.utils.sparse_model import SparseAutoModel
 
 
 class SparseML(AutoCausalLM):


### PR DESCRIPTION
This PR achieves 2 main features:
1. Adds support for bos_token and eos_token
2. Moves support to sparse models to a dedicated model class, keeping with the spirit of the lm-evaluation-harness implementation

lm-evaluation-harness disables the add_special_tokens argument for causal models because it interferes w/ how it composes the question and context for some multiple choice tasks. However, we want to be able to add bos_token to models that were trained with it. It has proved to have significant accuracy implications for some models.

Instead of supporting add_special_tokens in general, this PR gets around this by dealing only w/ bos_token and eos_token. I added logic on how to deal w/ these specific tokens in each case. To enable this, the user can set add_bos_token and/or add_eos_token in tokenizer_config.json (the pretrained Llama2 model does this).

After this change, the tokenization flow matches that of deepsparse