### PR TITLE
Add support to ClearML logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -98,13 +98,17 @@ def main():
     if args.clearml_project is not None and args.clearml_task is not None:
         from clearml import Task
         clearml_task = Task.get_task(project_name=args.clearml_project, task_name=args.clearml_task)
-        clearml_task.started()
+        if clearml_task is None:
+            clearml_task = Task.init(project_name=args.clearml_project, task_name=args.clearml_task)
+        else:
+            clearml_task.started()
+
         clearml_task.upload_artifact(name='lm-evaluation-harness output', artifact_object=results)
-        if "result" in results:
-            for task in results["result"]:
-                for metric in results["result"][task]:
+        if "results" in results:
+            for task in results["results"]:
+                for metric in results["results"][task]:
                     name = task + "_" + metric
-                    task.get_logger().report_single_value(name=name, value=results["result"][task][metric])
+                    task.get_logger().report_single_value(name=name, value=results["results"][task][metric])
         clearml_task.mark_completed()
 
     batch_sizes = ",".join(map(str, results["config"]["batch_sizes"]))

--- a/main.py
+++ b/main.py
@@ -107,7 +107,7 @@ def main():
         if "results" in results:
             for task in results["results"]:
                 for metric in results["results"][task]:
-                    name = task + "_" + metric
+                    name = task + "_" + args.num_fewshot + "shot_" + metric
                     clearml_task.get_logger().report_single_value(name=name, value=results["results"][task][metric])
         clearml_task.mark_completed()
 

--- a/main.py
+++ b/main.py
@@ -40,6 +40,8 @@ def parse_args():
     parser.add_argument("--check_integrity", action="store_true")
     parser.add_argument("--write_out", action="store_true", default=False)
     parser.add_argument("--output_base_path", type=str, default=None)
+    parser.add_argument("--clearml_project", type=str, default=None)
+    parser.add_argument("--clearml_task", type=str, default=None)
 
     return parser.parse_args()
 
@@ -92,6 +94,17 @@ def main():
             os.makedirs(dirname, exist_ok=True)
         with open(args.output_path, "w") as f:
             f.write(dumped)
+
+    if args.clearml_project is not None and args.clearml_task is not None:
+        from clearml import Task
+        clearml_task = Task.get_task(project_name=args.clearml_project, task_name=args.clearml_task)
+        clearml_task.upload_artifact(name='lm-evaluation-harness output', artifact_object=results)
+        if "result" in results:
+            for task in results["result"]:
+                for metric in results["result"][task]:
+                    name = task + "_" + metric
+                    task.get_logger().report_single_value(name=name, value=results["result"][task][metric])
+
 
     batch_sizes = ",".join(map(str, results["config"]["batch_sizes"]))
     print(

--- a/main.py
+++ b/main.py
@@ -107,7 +107,7 @@ def main():
         if "results" in results:
             for task in results["results"]:
                 for metric in results["results"][task]:
-                    name = task + "_" + args.num_fewshot + "shot_" + metric
+                    name = task + "_" + f"{args.num_fewshot}" + "shot_" + metric
                     clearml_task.get_logger().report_single_value(name=name, value=results["results"][task][metric])
         clearml_task.mark_completed()
 

--- a/main.py
+++ b/main.py
@@ -108,7 +108,7 @@ def main():
             for task in results["results"]:
                 for metric in results["results"][task]:
                     name = task + "_" + metric
-                    task.get_logger().report_single_value(name=name, value=results["results"][task][metric])
+                    clearml_task.get_logger().report_single_value(name=name, value=results["results"][task][metric])
         clearml_task.mark_completed()
 
     batch_sizes = ",".join(map(str, results["config"]["batch_sizes"]))

--- a/main.py
+++ b/main.py
@@ -98,13 +98,14 @@ def main():
     if args.clearml_project is not None and args.clearml_task is not None:
         from clearml import Task
         clearml_task = Task.get_task(project_name=args.clearml_project, task_name=args.clearml_task)
+        clearml_task.started()
         clearml_task.upload_artifact(name='lm-evaluation-harness output', artifact_object=results)
         if "result" in results:
             for task in results["result"]:
                 for metric in results["result"][task]:
                     name = task + "_" + metric
                     task.get_logger().report_single_value(name=name, value=results["result"][task][metric])
-
+        clearml_task.mark_completed()
 
     batch_sizes = ",".join(map(str, results["config"]["batch_sizes"]))
     print(


### PR DESCRIPTION
This PR adds support to logging lm-evaluation-harness results to ClearML.

The project and task names must both be provided as arguments in order to enable logging. If the project/task exists, the results will be appended to it, otherwise the corresponding project/task will be created from scratch.

The logging adds:
- an artifact with the complete json output from the harness
- one scalar value for each of the metrics under the "results" key of the json output, pre-appended by the evaluation task name

For instance, for gsm8k, the following artifact is added:

```
{
    "config": {
        "batch_size": "32",
        "batch_sizes": [],
        "bootstrap_iters": 100000,
        "description_dict": {},
        "device": "cuda:7",
        "limit": null,
        "model": "sparseml",
        "model_args": "pretrained=dense_finetuning/dense_LR1e-4_E4_GC5_extended,dtype=bfloat16",
        "no_cache": true,
        "num_fewshot": 0
    },
    "results": {
        "gsm8k": {
            "acc": 0.0841546626231994,
            "acc_stderr": 0.0076470240466032045
        }
    },
    "versions": {
        "gsm8k": 0
    }
}
```

and the following values are added the the "Summary" section of the Scalars tab:

gsm8k_acc: 0.0841546626231994
gsm8k_acc_stderr: 0.0076470240466032045